### PR TITLE
Remove hard-coded url and use the hostname provided by each Redmine i…

### DIFF
--- a/app/models/redmine_instance.rb
+++ b/app/models/redmine_instance.rb
@@ -1,5 +1,5 @@
 class RedmineInstance
-  attr_accessor :name, :server, :version, :plugins, :size, :admin,
+  attr_accessor :name, :server, :version, :plugins, :size, :url, :admin,
                 :nb_projects, :nb_tickets, :nb_users
 
   def self.all
@@ -34,6 +34,7 @@ class RedmineInstance
     @version = hsh["version"]
     @size = hsh["size"].to_i
     @admin = hsh["admin"]
+    @url = hsh["url"]
     @nb_projects = hsh["nb_projects"].to_i
     @nb_tickets = hsh["nb_tickets"].to_i
     @nb_users = hsh["nb_users"].to_i

--- a/app/views/saas/redmine.html.erb
+++ b/app/views/saas/redmine.html.erb
@@ -29,7 +29,7 @@
   </tr>
   <% instances.each do |instance| %>
   <tr>
-    <td><%= link_to instance.name, "http://#{instance.name}.projet.appli.i2/" %></td>
+    <td><%= link_to instance.name, instance.url %></td>
     <td class="center"><%= instance.admin %></td>
     <td class="center"><%= instance.version %></td>
     <% if show_plugins %><td class="center"><%= instance.plugins.join("<br/>").html_safe %></td><% end %>


### PR DESCRIPTION
Hi
I would like to remove hard-coded urls and use the hostname provided by each Redmine instance instead (we are not using ".i2" domains anymore here).
Can you please let me know if this PR can be merged?
Thank you